### PR TITLE
after-sharding Vitess cluster configuration on Kubernetes

### DIFF
--- a/mysql/Makefile
+++ b/mysql/Makefile
@@ -140,6 +140,9 @@ resharding_process:
 init_vreplication_articles:
 	$(SHARD_REPLICATION_CATEGORY_ARTICLE)
 
+final_vitess_cluster:
+	kubectl apply -f kubernetes/init_cluster_vitess_sharded_final.yaml
+
 copy_locations_json_to_k8s:
 	kubectl cp ./database/locations/locations.json $(shell kubectl get pods --selector="planetscale.com/component=vtctld" -o custom-columns=":metadata.name"):/tmp/countries.json
 	kubectl cp ./database/locations/locations.json $(shell kubectl get pods --selector="planetscale.com/component=vtgate" -o custom-columns=":metadata.name"):/tmp/countries.json

--- a/mysql/kubernetes/init_cluster_vitess_sharded_final.yaml
+++ b/mysql/kubernetes/init_cluster_vitess_sharded_final.yaml
@@ -1,0 +1,179 @@
+apiVersion: planetscale.com/v2
+kind: VitessCluster
+metadata:
+  name: vitess
+spec:
+  images:
+    vtctld: vitess/lite:v6.0.20-20200429
+    vtgate: vitess/lite:v6.0.20-20200429
+    vttablet: vitess/lite:v6.0.20-20200429
+    vtbackup: vitess/lite:v6.0.20-20200429
+    mysqld:
+      mysql56Compatible: vitess/lite:v6.0.20-20200429
+    mysqldExporter: prom/mysqld-exporter:v0.11.0
+  cells:
+    - name: zone1 # VTGATE
+      gateway:
+        authentication:
+          static:
+            secret:
+              name: vitess-cluster-secret
+              key: users.json
+        replicas: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 256Mi
+        extraVolumeMounts:
+          - name: vitess-region-config-volume
+            mountPath: /tmp/countries.json
+            subPath: countries.json
+          - name: vitess-region-config-volume
+            mountPath: /tmp/categories.json
+            subPath: categories.json
+        extraVolumes:
+          - name: vitess-region-config-volume
+            configMap:
+              name: vitess-cluster-config-sharding
+  vitessDashboard: # VTCTLD
+    cells:
+      - zone1
+    extraFlags:
+      security_policy: read-only
+    replicas: 1
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    extraVolumeMounts:
+      - name: vitess-region-config-volume
+        mountPath: /tmp/countries.json
+        subPath: countries.json
+      - name: vitess-region-config-volume
+        mountPath: /tmp/categories.json
+        subPath: categories.json
+    extraVolumes:
+      - name: vitess-region-config-volume
+        configMap:
+          name: vitess-cluster-config-sharding
+  keyspaces:
+    - name: articles
+      turndownPolicy: Immediate
+      partitionings:
+        - equal:
+            parts: 2
+            shardTemplate:
+              databaseInitScriptSecret:
+                name: vitess-cluster-secret
+                key: init_db.sql
+              replication:
+                enforceSemiSync: false
+              tabletPools:
+                - cell: zone1
+                  type: replica
+                  replicas: 3
+                  vttablet:
+                    extraFlags:
+                      db_charset: utf8mb4
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+                  mysqld:
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+                  dataVolumeClaimTemplate:
+                    accessModes: ["ReadWriteOnce"]
+                    resources:
+                      requests:
+                        storage: 10Gi
+                  extraVolumeMounts:
+                    - name: vitess-region-config-volume
+                      mountPath: /tmp/categories.json
+                      subPath: categories.json
+                  extraVolumes:
+                    - name: vitess-region-config-volume
+                      configMap:
+                        name: vitess-cluster-config-sharding
+
+    - name: users
+      turndownPolicy: Immediate
+      partitionings:
+        - equal:
+            parts: 2
+            shardTemplate:
+              databaseInitScriptSecret:
+                name: vitess-cluster-secret
+                key: init_db.sql
+              replication:
+                enforceSemiSync: false
+              tabletPools:
+                - cell: zone1
+                  type: replica
+                  replicas: 3
+                  vttablet:
+                    extraFlags:
+                      db_charset: utf8mb4
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+                  mysqld:
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+                  dataVolumeClaimTemplate:
+                    accessModes: ["ReadWriteOnce"]
+                    resources:
+                      requests:
+                        storage: 10Gi
+                  extraVolumeMounts:
+                    - name: vitess-region-config-volume
+                      mountPath: /tmp/countries.json
+                      subPath: countries.json
+                  extraVolumes:
+                    - name: vitess-region-config-volume
+                      configMap:
+                        name: vitess-cluster-config-sharding
+
+    - name: config
+      turndownPolicy: Immediate
+      partitionings:
+        - equal:
+            parts: 1
+            shardTemplate:
+              databaseInitScriptSecret:
+                name: vitess-cluster-secret
+                key: init_db.sql
+              replication:
+                enforceSemiSync: false
+              tabletPools:
+                - cell: zone1
+                  type: replica
+                  replicas: 2
+                  vttablet:
+                    extraFlags:
+                      db_charset: utf8mb4
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+                  mysqld:
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+                  dataVolumeClaimTemplate:
+                    accessModes: ["ReadWriteOnce"]
+                    resources:
+                      requests:
+                        storage: 10Gi
+  updateStrategy:
+    type: Immediate


### PR DESCRIPTION
Addition of the Kubernetes manifest file which will tear down the unused shards in keyspaces users and articles, and increases the replication form 2 to 3.