### PR TITLE
Creation of a new kubernetes namespace for vitess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,10 @@ clone_vitess_github:
 	./lib/script/get-vitess.sh
 
 install_vitess_operator:
+	kubectl apply -f kubernetes/vitess_namespace.yaml
+	kubectl config set-context $(shell kubectl config current-context) --namespace=vitess
 	kubectl apply -f $(VITESS_OPERATOR_PATH)/operator.yaml
+	kubectl config set-context $(shell kubectl config current-context) --namespace=default
 
 init_kubernetes_unsharded_database:
 	kubectl apply -f kubernetes/vitess_cluster_secret.yaml
@@ -157,7 +160,7 @@ setup_traefik:
 	@sleep 5
 	kubectl create -f kubernetes/traefik/traefik_deployment.yaml
 
-setup_traefik_vitess:
+setup_traefik_vitess: $(shell chmod +x ./kubernetes/traefik/vitess/build.sh)
 	./kubernetes/traefik/vitess/build.sh
 	kubectl create -f kubernetes/traefik/vitess/
 
@@ -169,7 +172,7 @@ copy_locations_json_to_k8s:
 	kubectl cp ./database/locations/locations.json $(shell kubectl get pods --selector="planetscale.com/component=vtgate" -o custom-columns=":metadata.name"):/tmp/countries.json
 
 show_vttablets:
-	kubectl get pods --selector="planetscale.com/component=vttablet" -o custom-columns=":metadata.name" 
+	kubectl get pods --namespace=vitess --selector="planetscale.com/component=vttablet" -o custom-columns=":metadata.name" 
 
 show_vitess_tablets:
 	echo "show vitess_tablets;" | $(MYSQL_CLIENT) --table

--- a/kubernetes/init_cluster_vitess.yaml
+++ b/kubernetes/init_cluster_vitess.yaml
@@ -2,6 +2,7 @@ apiVersion: planetscale.com/v2
 kind: VitessCluster
 metadata:
   name: vitess
+  namespace: vitess
 spec:
   images:
     vtctld: vitess/lite:v6.0.20-20200429

--- a/kubernetes/init_cluster_vitess_sharded.yaml
+++ b/kubernetes/init_cluster_vitess_sharded.yaml
@@ -2,6 +2,7 @@ apiVersion: planetscale.com/v2
 kind: VitessCluster
 metadata:
   name: vitess
+  namespace: vitess
 spec:
   images:
     vtctld: vitess/lite:v6.0.20-20200429

--- a/kubernetes/init_cluster_vitess_sharded_final.yaml
+++ b/kubernetes/init_cluster_vitess_sharded_final.yaml
@@ -2,6 +2,7 @@ apiVersion: planetscale.com/v2
 kind: VitessCluster
 metadata:
   name: vitess
+  namespace: vitess
 spec:
   images:
     vtctld: vitess/lite:v6.0.20-20200429

--- a/kubernetes/init_namespaces.yaml
+++ b/kubernetes/init_namespaces.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vitess-cluster
-  labels:
-    name: vitess-cluster

--- a/kubernetes/traefik/vitess/build.sh
+++ b/kubernetes/traefik/vitess/build.sh
@@ -2,7 +2,7 @@
 
 cd "${0%/*}"
 
-yq w -i vitess_vtctld_ingress_route.yaml "spec.routes[0].services[0].name" $(kubectl get service --selector="planetscale.com/component=vtctld" -o custom-columns=":metadata.name" | head -n2)
-yq w -i vitess_vtctld_client_ingress_route.yaml "spec.routes[0].services[0].name" $(kubectl get service --selector="planetscale.com/component=vtctld" -o custom-columns=":metadata.name" | head -n2)
-yq w -i vitess_vtgate_ingress_route.yaml "spec.routes[0].services[0].name" $(kubectl get service --selector="planetscale.com/component=vtgate" -o custom-columns=":metadata.name" | head -n2)
-yq w -i vitess_vttablet_ingress_route.yaml "spec.routes[0].services[0].name" $(kubectl get service --selector="planetscale.com/component=vttablet" -o custom-columns=":metadata.name" | head -n2)
+yq w -i vitess_vtctld_ingress_route.yaml "spec.routes[0].services[0].name" $(kubectl get service --namespace=vitess --selector="planetscale.com/component=vtctld" -o custom-columns=":metadata.name" | head -n2)
+yq w -i vitess_vtctld_client_ingress_route.yaml "spec.routes[0].services[0].name" $(kubectl get service --namespace=vitess --selector="planetscale.com/component=vtctld" -o custom-columns=":metadata.name" | head -n2)
+yq w -i vitess_vtgate_ingress_route.yaml "spec.routes[0].services[0].name" $(kubectl get service --namespace=vitess --selector="planetscale.com/component=vtgate" -o custom-columns=":metadata.name" | head -n2)
+yq w -i vitess_vttablet_ingress_route.yaml "spec.routes[0].services[0].name" $(kubectl get service --namespace=vitess --selector="planetscale.com/component=vttablet" -o custom-columns=":metadata.name" | head -n2)

--- a/kubernetes/traefik/vitess/vitess_vtctld_client_ingress_route.yaml
+++ b/kubernetes/traefik/vitess/vitess_vtctld_client_ingress_route.yaml
@@ -2,6 +2,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: vtctld-client
+  namespace: vitess
 spec:
   entryPoints:
     - grpc
@@ -9,5 +10,6 @@ spec:
     - kind: Rule
       match: HostSNI(`*`)
       services:
-        - name: vitess-vtctld-047eb1a6
+        - namespace: vitess
+          name: vitess-vtctld-047eb1a6
           port: 15999

--- a/kubernetes/traefik/vitess/vitess_vtctld_ingress_route.yaml
+++ b/kubernetes/traefik/vitess/vitess_vtctld_ingress_route.yaml
@@ -2,6 +2,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: vtctld-web
+  namespace: vitess
 spec:
   entryPoints:
     - web
@@ -9,15 +10,18 @@ spec:
     - kind: Rule
       match: Host(`tagenal`) && PathPrefix(`/vtctld`)
       services:
-        - name: vitess-vtctld-047eb1a6
+        - namespace: vitess
+          name: vitess-vtctld-047eb1a6
           port: 15000
       middlewares:
-        - name: vtctld-web-stripprefix
+        - namespace: vitess
+          name: vtctld-web-stripprefix
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: vtctld-web-stripprefix
+  namespace: vitess
 spec:
   stripPrefix:
     prefixes:

--- a/kubernetes/traefik/vitess/vitess_vtgate_ingress_route.yaml
+++ b/kubernetes/traefik/vitess/vitess_vtgate_ingress_route.yaml
@@ -2,6 +2,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: vtgate-mysql
+  namespace: vitess
 spec:
   entryPoints:
     - mysql
@@ -9,5 +10,6 @@ spec:
     - kind: Rule
       match: HostSNI(`*`)
       services:
-        - name: vitess-vtgate-e05d80f4
+        - namespace: vitess
+          name: vitess-vtgate-e05d80f4
           port: 3306

--- a/kubernetes/traefik/vitess/vitess_vttablet_ingress_route.yaml
+++ b/kubernetes/traefik/vitess/vitess_vttablet_ingress_route.yaml
@@ -2,6 +2,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: vttablet-web
+  namespace: vitess
 spec:
   entryPoints:
     - web
@@ -9,15 +10,18 @@ spec:
     - kind: Rule
       match: Host(`tagenal`) && PathPrefix(`/vttablet`)
       services:
-        - name: vitess-vttablet-5613eb8f
+        - namespace: vitess
+          name: vitess-vttablet-5613eb8f
           port: 9104
       middlewares:
-        - name: vttablet-web-stripprefix
+        - namespace: vitess
+          name: vttablet-web-stripprefix
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: vttablet-web-stripprefix
+  namespace: vitess
 spec:
   stripPrefix:
     prefixes:

--- a/kubernetes/vitess_cluster_config.yaml
+++ b/kubernetes/vitess_cluster_config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vitess-cluster-config-sharding
-  namespace: default
+  namespace: vitess
 data:
   countries.json: |
     {

--- a/kubernetes/vitess_cluster_secret.yaml
+++ b/kubernetes/vitess_cluster_secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vitess-cluster-secret
+  namespace: vitess
 type: Opaque
 stringData:
   users.json: |

--- a/kubernetes/vitess_namespace.yaml
+++ b/kubernetes/vitess_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vitess

--- a/monitoring/monitoring.jsonnet
+++ b/monitoring/monitoring.jsonnet
@@ -36,7 +36,7 @@ local kp =
         kind: 'ServiceMonitor',
         metadata: {
           name: 'vitess-monitor-service',
-          namespace: 'default',
+          namespace: 'vitess',
         },
         spec: {
           jobLabel: 'vitess-cluster',


### PR DESCRIPTION
A new Kubernetes namespace was added and contains the whole Vitess cluster. The corresponding modifications have been reported in prometheus' and Traefik's configurations.