### PR TITLE
Removal of port-forwarding and other deprecated make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,6 @@ init_kubernetes_unsharded_database:
 	kubectl apply -f kubernetes/init_cluster_vitess.yaml
 	kubectl apply -f kubernetes/vitess_vtgate_service.yaml
 
-port_forwarding_vitess:
-	./script/port_forwarding.sh
-
 init_unsharded_database:
 	$(INIT_USERS_TABLES)
 	$(INIT_USERS_VSCHEMA)
@@ -179,10 +176,6 @@ setup_traefik_vitess: $(shell chmod +x ./kubernetes/traefik/vitess/build.sh)
 
 setup_traefik_monitoring:
 	kubectl create -f kubernetes/traefik/monitoring/
-
-copy_locations_json_to_k8s:
-	kubectl cp ./database/locations/locations.json $(shell kubectl get pods --selector="planetscale.com/component=vtctld" -o custom-columns=":metadata.name"):/tmp/countries.json
-	kubectl cp ./database/locations/locations.json $(shell kubectl get pods --selector="planetscale.com/component=vtgate" -o custom-columns=":metadata.name"):/tmp/countries.json
 
 show_vttablets:
 	kubectl get pods --namespace=vitess --selector="planetscale.com/component=vttablet" -o custom-columns=":metadata.name" 

--- a/monitoring/port_forwarding.sh
+++ b/monitoring/port_forwarding.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-kubectl --namespace monitoring port-forward svc/prometheus-k8s 9090 &
-
-kubectl --namespace monitoring port-forward svc/grafana 3000 &
-
-kubectl --namespace monitoring port-forward svc/alertmanager-main 9093 &

--- a/scripts/port_forwarding.sh
+++ b/scripts/port_forwarding.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# TODO: redirect the output of Vtctld into a log files rather than stdout
-kubectl port-forward "$(kubectl get service --selector="planetscale.com/component=vtctld" -o name | head -n1)" 15000 15999 &
-
-kubectl port-forward "$(kubectl get service --selector="planetscale.com/component=vtgate" -o name | head -n1)" 15306:3306 &
-
-kubectl port-forward "$(kubectl get service --selector="planetscale.com/component=vttablet" -o name | head -n1)" 9104:9104 &


### PR DESCRIPTION
The port forwarding rules and shell scripts are deleted. Since the introduction of Traefik, they are no longer in use as mentioned in #15.

Additionally, the `copy_locations_json_to_k8s` got removed. This command was also unused since the implementation of the `ConfigMap` for the geo-fragmentation of Vitess.